### PR TITLE
Fix Firecrawl API call parameters

### DIFF
--- a/fetcher/crawling_fetcher.py
+++ b/fetcher/crawling_fetcher.py
@@ -35,12 +35,10 @@ def fetch_articles_by_crawling(news_websites_crawl: dict,
             logger.info(f"[Crawling] Website: {website}, with rules: {rules}")
             crawl_status = app.crawl_url(
                 website,
-                params={
-                    'limit': rules.get('limit', 2),
-                    'scrapeOptions': {'formats': ['markdown', 'html']},
-                    'includePaths': include_paths,
-                    'excludePaths': rules.get('excludePaths', []),
-                },
+                limit=rules.get('limit', 2),
+                scrapeOptions={'formats': ['markdown', 'html']},
+                includePaths=include_paths,
+                excludePaths=rules.get('excludePaths', []),
                 poll_interval=1
             )
 

--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -21,7 +21,10 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
     for url in news_websites_scraping:
         try:
             logger.info(f"[Scraping] Fetching URL: {url}")
-            scrape_result = app.scrape_url(url, params={'formats': ['markdown', 'html']})
+            scrape_result = app.scrape_url(
+                url,
+                formats=['markdown', 'html']
+            )
             # 如果有 markdown，就代表成功抓取到内容
             if scrape_result and 'markdown' in scrape_result:
                 # 保持和原有逻辑类似，封装成一个 list


### PR DESCRIPTION
## Summary
- update crawler to use top-level parameters for crawl_url
- update scraper to use formats keyword for scrape_url

## Testing
- `pytest -q` *(fails: command not found)*