### PR TITLE
Fix Firecrawl API usage

### DIFF
--- a/fetcher/crawling_fetcher.py
+++ b/fetcher/crawling_fetcher.py
@@ -1,7 +1,7 @@
 # fetcher/crawling_fetcher.py
 import logging
 import os
-from firecrawl import FirecrawlApp
+from firecrawl import FirecrawlApp, ScrapeOptions
 
 logger = logging.getLogger(__name__)
 
@@ -35,13 +35,11 @@ def fetch_articles_by_crawling(news_websites_crawl: dict,
             logger.info(f"[Crawling] Website: {website}, with rules: {rules}")
             crawl_status = app.crawl_url(
                 website,
-                params={
-                    'limit': rules.get('limit', 2),
-                    'scrapeOptions': {'formats': ['markdown', 'html']},
-                    'includePaths': include_paths,
-                    'excludePaths': rules.get('excludePaths', []),
-                },
-                poll_interval=1
+                limit=rules.get('limit', 2),
+                include_paths=include_paths,
+                exclude_paths=rules.get('excludePaths', []),
+                scrape_options=ScrapeOptions(formats=["markdown", "html"]),
+                poll_interval=1,
             )
 
             news_articles = crawl_status.get('data', [])

--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -1,7 +1,7 @@
 # fetcher/scraping_fetcher.py
 import logging
 import os
-from firecrawl import FirecrawlApp
+from firecrawl import FirecrawlApp, ScrapeOptions
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,10 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
     for url in news_websites_scraping:
         try:
             logger.info(f"[Scraping] Fetching URL: {url}")
-            scrape_result = app.scrape_url(url, params={'formats': ['markdown', 'html']})
+            scrape_result = app.scrape_url(
+                url,
+                scrape_options=ScrapeOptions(formats=["markdown", "html"]),
+            )
             # 如果有 markdown，就代表成功抓取到内容
             if scrape_result and 'markdown' in scrape_result:
                 # 保持和原有逻辑类似，封装成一个 list


### PR DESCRIPTION
## Summary
- adapt fetchers to Firecrawl SDK v2

## Testing
- `python -m py_compile fetcher/crawling_fetcher.py fetcher/scraping_fetcher.py`
- `python -m pytest -q` *(fails: No module named pytest)*