### PR TITLE
Split crawl config into two files

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "$FIREBASE_KEY" > serviceAccountKey.json
 
-      - name: Run Podcast Generator
+      - name: Run Podcast Generator for Coindesk
         env:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -64,6 +64,18 @@ jobs:
           SCRAPING_CONFIG: ${{ github.event.inputs.scraping_config || '{}' }}
           FETCHER_METHOD: ${{ github.event.inputs.method || 'crawling' }}
           BE_CONCISE: ${{ github.event.inputs.be_concise || 'true' }}
+          CRAWL_CONFIG_FILE: news_websites_crawl_coindesk.json
+        run: python main.py
+
+      - name: Run Podcast Generator for Reuters
+        env:
+          FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          SCRAPING_CONFIG: ${{ github.event.inputs.scraping_config || '{}' }}
+          FETCHER_METHOD: ${{ github.event.inputs.method || 'crawling' }}
+          BE_CONCISE: ${{ github.event.inputs.be_concise || 'true' }}
+          CRAWL_CONFIG_FILE: news_websites_crawl_reuters.json
         run: python main.py
 
       - name: Send mail

--- a/main.py
+++ b/main.py
@@ -35,11 +35,12 @@ def main():
     coindesk_date_tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y/%m/%d")
 
     # 4. 加载或解析爬取/抓取配置
+    crawl_config_file = os.getenv("CRAWL_CONFIG_FILE", "news_websites_crawl_coindesk.json")
     try:
-        news_websites_crawl = load_json_config("news_websites_crawl.json")
-        logger.info("Successfully loaded news_websites_crawl.json configuration.")
+        news_websites_crawl = load_json_config(crawl_config_file)
+        logger.info(f"Successfully loaded {crawl_config_file} configuration.")
     except Exception as e:
-        logger.error(f"Failed to load news_websites_crawl.json: {e}")
+        logger.error(f"Failed to load {crawl_config_file}: {e}")
         news_websites_crawl = {}
 
     # 5. 根据环境变量或本地文件加载 scraping 配置

--- a/news_websites_crawl.json
+++ b/news_websites_crawl.json
@@ -1,7 +1,0 @@
-{
-  "https://www.coindesk.com": {
-      "limit": 20,
-      "includePaths": [],
-      "excludePaths": []
-  }
-}

--- a/news_websites_crawl_coindesk.json
+++ b/news_websites_crawl_coindesk.json
@@ -1,0 +1,7 @@
+{
+  "https://www.coindesk.com": {
+    "limit": 10,
+    "includePaths": [],
+    "excludePaths": []
+  }
+}

--- a/news_websites_crawl_reuters.json
+++ b/news_websites_crawl_reuters.json
@@ -1,0 +1,10 @@
+{
+  "https://www.reuters.com": {
+    "limit": 10,
+    "includePaths": [],
+    "excludePaths": [
+      "wrapup",
+      "podcasts"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- parameterize crawl config path via `CRAWL_CONFIG_FILE`
- add Coindesk and Reuters crawl configs separately
- update workflow to run podcast generator twice with each config

## Testing
- `pytest -q` *(fails: command not found)*