### PR TITLE
Handle Firecrawl model objects

### DIFF
--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -25,11 +25,18 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
                 url,
                 scrape_options=ScrapeOptions(formats=["markdown", "html"]),
             )
-            # 如果有 markdown，就代表成功抓取到内容
-            if scrape_result and 'markdown' in scrape_result:
-                # 保持和原有逻辑类似，封装成一个 list
-                news_articles = [scrape_result]
-                all_articles.extend(news_articles)
+
+            # firecrawl-py >= 2 returns a model; convert to dict so existing
+            # code using dict access continues to work
+            if scrape_result:
+                if not isinstance(scrape_result, dict):
+                    scrape_result = scrape_result.model_dump()
+
+                # 如果有 markdown，就代表成功抓取到内容
+                if "markdown" in scrape_result:
+                    # 保持和原有逻辑类似，封装成一个 list
+                    news_articles = [scrape_result]
+                    all_articles.extend(news_articles)
         except Exception as e:
             logger.error(f"Error scraping {url}: {e}")
 

--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -108,6 +108,10 @@ def summarize_and_tts_articles(news_articles, client, model_name, output_folder,
     all_summaries = []
 
     for idx, article in enumerate(news_articles):
+        # results from firecrawl-py may be Pydantic models; convert to dict
+        if not isinstance(article, dict):
+            article = article.model_dump()
+
         url = article.get('metadata', {}).get('sourceURL', '')
 
         logger.info(f"Summarizing article {idx + 1}: {url}")    


### PR DESCRIPTION
## Summary
- handle firecrawl-py >=2 returning pydantic models
- normalize crawled and scraped data
- tolerate model objects in podcast generator

## Testing
- `pytest -q` *(fails: command not found)*