### PR TITLE
Fix missing DashScope API key in workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           SCRAPING_CONFIG: ${{ github.event.inputs.scraping_config || '{}' }}
           FETCHER_METHOD: ${{ github.event.inputs.method || 'crawling' }}
@@ -71,6 +72,7 @@ jobs:
         env:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           SCRAPING_CONFIG: ${{ github.event.inputs.scraping_config || '{}' }}
           FETCHER_METHOD: ${{ github.event.inputs.method || 'crawling' }}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This script automates the process of crawling news websites, summarizing article
 	•	FIRECRAWL_API_KEY: Your Firecrawl API key.
 
 	•	GH_ACCESS_TOKEN: Your GitHub access token.
+	•	DASHSCOPE_API_KEY: Your DashScope API key.
 
 2.	Update the script:
 


### PR DESCRIPTION
## Summary
- ensure the workflow provides the `DASHSCOPE_API_KEY` for both Coindesk and Reuters runs
- document the new environment variable in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`