### PR TITLE
Remove 'UC' prefix from podcast greeting

### DIFF
--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -266,7 +266,7 @@ def generate_intro_ending(all_summaries, client, model_name, output_folder):
 
         the opening:
         Combine the following article summaries into an introduction for today's news podcast. Start with a greeting and then provide a comprehensive summary of the main topics.
-        The important thing is to create a true synthesis that captures trends and significance, rather than simply listing each news item briefly. the opening should start with "欢迎收听今天的UC播客"
+        The important thing is to create a true synthesis that captures trends and significance, rather than simply listing each news item briefly. the opening should start with "欢迎收听今天的播客"
 
         the title:
         Provide a podcast title


### PR DESCRIPTION
## Summary
- update podcast intro prompt so the opening says "欢迎收听今天的播客" instead of "欢迎收听今天的UC播客"

## Testing
- `python -m py_compile $(git ls-files '*.py')`