### PR TITLE
Add DeepSeek API support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -66,6 +66,7 @@ jobs:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           COS_BUCKET: ${{ secrets.COS_BUCKET }}
           COS_PATH: ${{ secrets.COS_PATH }}
@@ -84,6 +85,7 @@ jobs:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           COS_BUCKET: ${{ secrets.COS_BUCKET }}
           COS_PATH: ${{ secrets.COS_PATH }}

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ pip install -r requirements.txt
 1. 将 Firebase 的 `serviceAccountKey.json` 放在项目根目录。
 2. 设置环境变量：
    - `FIRECRAWL_API_KEY`：Firecrawl API Key。
-   - `OPENAI_API_KEY` 或 `DASHSCOPE_API_KEY`：用于摘要和语音合成的 Key。
- - `GH_ACCESS_TOKEN`：如果需通过 GitHub Actions 推送结果，则需要该 Token。
+   - `OPENAI_API_KEY`、`DASHSCOPE_API_KEY` 或 `DEEPSEEK_API_KEY`：用于摘要和语音合成的 Key。
+   - `GH_ACCESS_TOKEN`：如果需通过 GitHub Actions 推送结果，则需要该 Token。
 3. 修改 `news_websites_crawl_*.json` 或 `news_websites_scraping.json` 以配置要抓取的网站和路径。
 4. 如需按日期扩展抓取路径，可编辑 `news_dynamic_paths.json`（或通过环境变量 `DYNAMIC_DATE_CONFIG` 指定其他文件），默认已包含 Reuters、CoinDesk、news.smol.ai 的示例。
 
@@ -59,7 +59,9 @@ pip install -r requirements.txt
 - `OPENAI_MODEL`：OpenAI 模型名称，默认 `gpt-4o`。
 - `DASHSCOPE_API_KEY`：阿里云百炼 API Key，`SUMMARY_PROVIDER=tongyi` 时使用。
 - `DASHSCOPE_MODEL`：阿里云模型名称，默认 `qwen-plus`。
-- `SUMMARY_PROVIDER`：选择 `openai` 或 `tongyi` 作为摘要和文生图的提供方，默认 `tongyi`。
+- `DEEPSEEK_API_KEY`：DeepSeek API Key，`SUMMARY_PROVIDER=deepseek` 时使用。
+- `DEEPSEEK_MODEL`：DeepSeek 模型名称，默认 `deepseek-chat`。
+- `SUMMARY_PROVIDER`：选择 `openai`、`tongyi` 或 `deepseek` 作为摘要和文生图的提供方，默认 `tongyi`。
 - `BE_CONCISE`：设为 `true` 时生成更简洁的摘要。
 - `FETCHER_METHOD`：`crawling`（默认）或 `scraping`，决定新闻获取方式。
 - `CRAWL_CONFIG_FILE`：爬取配置文件路径，默认为 `news_websites_crawl_coindesk.json`。

--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -31,6 +31,12 @@ def initialize_llm_client():
             raise ValueError("OPENAI_API_KEY not set in environment variables.")
         client = OpenAI(api_key=api_key)
         model_name = os.getenv("OPENAI_MODEL", "gpt-4o")
+    elif provider == "deepseek":
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            raise ValueError("DEEPSEEK_API_KEY not set in environment variables.")
+        client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1")
+        model_name = os.getenv("DEEPSEEK_MODEL", "deepseek-chat")
     else:
         api_key = os.getenv("DASHSCOPE_API_KEY")
         if not api_key:


### PR DESCRIPTION
## Summary
- support `deepseek` provider in `podcast_generator.py`
- document new DeepSeek environment variables
- pass DeepSeek credentials in workflow

## Testing
- `python -m py_compile podcast_generator.py`
