### PR TITLE
Update image generation defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pip install -r requirements.txt
 - `FIRECRAWL_API_KEY`：Firecrawl API Key，用于爬取或抓取文章。
 - `OPENAI_API_KEY`：当 `SUMMARY_PROVIDER=openai` 时使用的 API Key。
 - `OPENAI_MODEL`：OpenAI 模型名称，默认 `gpt-4o`。
+- 播客封面图片通过 `gpt-image-1` 生成，分辨率 `1024x1024`、质量 `standard`（约 0.04 USD）。
 - `DASHSCOPE_API_KEY`：阿里云百炼 API Key，`SUMMARY_PROVIDER=tongyi` 时使用。
 - `DASHSCOPE_MODEL`：阿里云模型名称，默认 `qwen-plus`。
 - `DEEPSEEK_API_KEY`：DeepSeek API Key，`SUMMARY_PROVIDER=deepseek` 时使用。

--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -21,6 +21,11 @@ import time
 
 logger = logging.getLogger(__name__)
 
+# Default settings for GPT image generation
+IMAGE_MODEL = "gpt-image-1"
+IMAGE_SIZE = "1024x1024"
+IMAGE_QUALITY = "standard"
+
 # 根据环境变量初始化 LLM 客户端
 def initialize_llm_client():
     """Return (client, model_name) based on SUMMARY_PROVIDER env."""
@@ -410,15 +415,15 @@ def generate_and_upload_cover_image(title, description, client, output_folder):
 
     # 调用图像生成
     intro_response = image_client.images.generate(
-        model="gpt-image-1",
+        model=IMAGE_MODEL,
         prompt=image_prompt,
         n=1,
-        size="1024x1024",
-        quality="standard",
+        size=IMAGE_SIZE,
+        quality=IMAGE_QUALITY,
         response_format="url"
     )
     image_url = intro_response.data[0].url
-    logger.info(f"Image generated from gpt-image-1: {image_url}")
+    logger.info(f"Image generated from {IMAGE_MODEL}: {image_url}")
 
     # 下载并压缩图像
     image_data = requests.get(image_url).content

--- a/wash_list.py
+++ b/wash_list.py
@@ -33,6 +33,11 @@ COS_IMAGE_BASE_URL = "https://news-fetcher-1307107697.cos.ap-guangzhou.myqcloud.
 # MP3文件的基础URL
 MP3_BASE_URL = "https://downloadfile-a6lubplbza-uc.a.run.app?filename="
 
+# ----- image generation defaults -----
+IMAGE_MODEL = "gpt-image-1"
+IMAGE_SIZE = "1024x1024"
+IMAGE_QUALITY = "standard"
+
 def exponential_backoff_retry(func, *args, max_retries=5, **kwargs):
     """
     通用指数退避重试函数:
@@ -62,11 +67,11 @@ def generate_img_url(title, description):
     # 使用指数退避重试生成图像
     intro_response = exponential_backoff_retry(
         client.images.generate,
-        model="gpt-image-1",
+        model=IMAGE_MODEL,
         prompt=image_prompt,
         n=1,
-        size="1024x1024",
-        quality="standard",
+        size=IMAGE_SIZE,
+        quality=IMAGE_QUALITY,
         response_format="url"
     )
 


### PR DESCRIPTION
## Summary
- centralize GPT image generation settings
- use the new constants in both podcast generator and wash tools
- document that cover images are produced with gpt-image-1 at 1024x1024 standard quality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*