### PR TITLE
centralize image config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ pip install -r requirements.txt
 - **news_websites_scraping.json**：直接抓取的文章 URL 列表，用于无需站点爬取时的场景。
 - **news_dynamic_paths.json**：根据站点关键字提供日期格式和 `days_offset`，在运行时自动生成 `includePaths`。
 - **serviceAccountKey.json**：Firebase 凭证文件，需放在项目根目录。
+- **image_generation_config.json**：配置播客封面图片生成的模型、尺寸和质量。
 
 ### 环境变量说明
 
 - `FIRECRAWL_API_KEY`：Firecrawl API Key，用于爬取或抓取文章。
 - `OPENAI_API_KEY`：当 `SUMMARY_PROVIDER=openai` 时使用的 API Key。
 - `OPENAI_MODEL`：OpenAI 模型名称，默认 `gpt-4o`。
-- 播客封面图片通过 `gpt-image-1` 生成，分辨率 `1024x1024`、质量 `standard`（约 0.04 USD）。
+- 图片生成配置可在 `image_generation_config.json` 中调整，包括模型、尺寸和质量。
 - `DASHSCOPE_API_KEY`：阿里云百炼 API Key，`SUMMARY_PROVIDER=tongyi` 时使用。
 - `DASHSCOPE_MODEL`：阿里云模型名称，默认 `qwen-plus`。
 - `DEEPSEEK_API_KEY`：DeepSeek API Key，`SUMMARY_PROVIDER=deepseek` 时使用。
@@ -69,6 +70,7 @@ pip install -r requirements.txt
 - `SCRAPING_CONFIG`：直接传入的抓取配置 JSON 字符串，优先级高于本地文件。
 - `DYNAMIC_DATE_CONFIG`：动态日期配置文件路径，默认为 `news_dynamic_paths.json`。
 - `GH_ACCESS_TOKEN`：如需通过 GitHub Actions 推送结果时使用。
+- `IMAGE_GEN_CONFIG_FILE`：图片生成配置文件路径，默认为 `image_generation_config.json`。
 - `COS_SECRET_ID`、`COS_SECRET_KEY`、`COS_REGION`、`COS_BUCKET`、`COS_PATH`：配置腾讯云 COS 上传所需的凭据及路径。
 
 ## 使用方法

--- a/image_generation_config.json
+++ b/image_generation_config.json
@@ -1,0 +1,5 @@
+{
+  "model": "gpt-image-1",
+  "size": "1024x1024",
+  "quality": "standard"
+}

--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -14,6 +14,7 @@ from utils.firebase_utils import is_url_fetched, add_url_to_fetched, upload_to_f
 from utils.cos_utils import upload_file_to_cos
 from utils.image_utils import compress_image
 from utils.audio_utils import merge_audio_files, extract_domain, calculate_sha256
+from utils.common_utils import load_json_config
 from pydub import AudioSegment
 # 导入阿里云百炼语音合成SDK
 from dashscope.audio.tts_v2 import *
@@ -21,10 +22,19 @@ import time
 
 logger = logging.getLogger(__name__)
 
-# Default settings for GPT image generation
-IMAGE_MODEL = "gpt-image-1"
-IMAGE_SIZE = "1024x1024"
-IMAGE_QUALITY = "standard"
+# Load image generation config
+IMAGE_CONFIG_FILE = os.getenv("IMAGE_GEN_CONFIG_FILE", "image_generation_config.json")
+try:
+    image_cfg = load_json_config(IMAGE_CONFIG_FILE)
+    IMAGE_MODEL = image_cfg.get("model", "gpt-image-1")
+    IMAGE_SIZE = image_cfg.get("size", "1024x1024")
+    IMAGE_QUALITY = image_cfg.get("quality", "standard")
+    logger.info(f"Loaded image config from {IMAGE_CONFIG_FILE}")
+except Exception as e:
+    logger.error(f"Failed to load {IMAGE_CONFIG_FILE}: {e}")
+    IMAGE_MODEL = "gpt-image-1"
+    IMAGE_SIZE = "1024x1024"
+    IMAGE_QUALITY = "standard"
 
 # 根据环境变量初始化 LLM 客户端
 def initialize_llm_client():

--- a/wash_list.py
+++ b/wash_list.py
@@ -11,6 +11,7 @@ from firebase_admin import credentials, db
 import uuid
 from utils.cos_utils import upload_file_to_cos
 from utils.image_utils import compress_image
+from utils.common_utils import load_json_config
 from mutagen.mp3 import MP3
 from io import BytesIO  # 用于处理内存中的MP3数据
 
@@ -33,10 +34,19 @@ COS_IMAGE_BASE_URL = "https://news-fetcher-1307107697.cos.ap-guangzhou.myqcloud.
 # MP3文件的基础URL
 MP3_BASE_URL = "https://downloadfile-a6lubplbza-uc.a.run.app?filename="
 
-# ----- image generation defaults -----
-IMAGE_MODEL = "gpt-image-1"
-IMAGE_SIZE = "1024x1024"
-IMAGE_QUALITY = "standard"
+# ----- image generation config -----
+IMAGE_CONFIG_FILE = os.getenv("IMAGE_GEN_CONFIG_FILE", "image_generation_config.json")
+try:
+    image_cfg = load_json_config(IMAGE_CONFIG_FILE)
+    IMAGE_MODEL = image_cfg.get("model", "gpt-image-1")
+    IMAGE_SIZE = image_cfg.get("size", "1024x1024")
+    IMAGE_QUALITY = image_cfg.get("quality", "standard")
+    logger.info(f"Loaded image config from {IMAGE_CONFIG_FILE}")
+except Exception as e:
+    logger.error(f"Failed to load {IMAGE_CONFIG_FILE}: {e}")
+    IMAGE_MODEL = "gpt-image-1"
+    IMAGE_SIZE = "1024x1024"
+    IMAGE_QUALITY = "standard"
 
 def exponential_backoff_retry(func, *args, max_retries=5, **kwargs):
     """


### PR DESCRIPTION
## Summary
- centralize image generation config in `image_generation_config.json`
- load this file in podcast and wash scripts
- document new file and env variable

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*