### PR TITLE
Update Firecrawl calls for SDK v2

### DIFF
--- a/fetcher/crawling_fetcher.py
+++ b/fetcher/crawling_fetcher.py
@@ -1,7 +1,7 @@
 # fetcher/crawling_fetcher.py
 import logging
 import os
-from firecrawl import FirecrawlApp, ScrapeOptions
+from firecrawl import FirecrawlApp
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +36,12 @@ def fetch_articles_by_crawling(news_websites_crawl: dict,
             logger.info(f"[Crawling] Website: {website}, with rules: {rules}")
             crawl_status = app.crawl_url(
                 website,
-                limit=rules.get('limit', 2),
-                include_paths=include_paths,
-                exclude_paths=rules.get('excludePaths', []),
-                scrape_options=ScrapeOptions(formats=["markdown", "html"]),
+                params={
+                    "limit": rules.get('limit', 2),
+                    "includePaths": include_paths,
+                    "excludePaths": rules.get('excludePaths', []),
+                    "scrapeOptions": {"formats": ["markdown", "html"]},
+                },
                 poll_interval=1,
             )
 

--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -1,7 +1,7 @@
 # fetcher/scraping_fetcher.py
 import logging
 import os
-from firecrawl import FirecrawlApp, ScrapeOptions
+from firecrawl import FirecrawlApp
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
             logger.info(f"[Scraping] Fetching URL: {url}")
             scrape_result = app.scrape_url(
                 url,
-                scrape_options=ScrapeOptions(formats=["markdown", "html"]),
+                params={"formats": ["markdown", "html"]},
             )
 
             # firecrawl-py >= 2 returns a model; convert to dict so existing


### PR DESCRIPTION
## Summary
- update scraping and crawling fetchers for Firecrawl SDK 2.x

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*