### PR TITLE
Fix ScrapeOptions usage for firecrawl v2

### DIFF
--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -21,10 +21,11 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
     for url in news_websites_scraping:
         try:
             logger.info(f"[Scraping] Fetching URL: {url}")
-            scrape_result = app.scrape_url(
-                url,
-                scrape_options=ScrapeOptions(formats=["markdown", "html"]),
-            )
+            # firecrawl-py >= 2 removed the scrape_options parameter from
+            # `scrape_url`. To continue reusing ``ScrapeOptions`` we convert the
+            # Pydantic model to a dict and pass it as kwargs.
+            options = ScrapeOptions(formats=["markdown", "html"]).model_dump()
+            scrape_result = app.scrape_url(url, **options)
 
             # firecrawl-py >= 2 returns a model; convert to dict so existing
             # code using dict access continues to work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 openai
 pydub
-firecrawl
+firecrawl>=2.0
 pygithub
 firebase_admin
 tiktoken


### PR DESCRIPTION
## Summary
- adapt scraper to new `firecrawl-py` 2.0 API by converting `ScrapeOptions` to kwargs
- require `firecrawl` version 2.0+

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*