### PR TITLE
Add waitFor options for scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ pip install -r requirements.txt
 - `DASHSCOPE_MODEL`：阿里云模型名称，默认 `qwen-plus`。
 - `DEEPSEEK_API_KEY`：DeepSeek API Key，`SUMMARY_PROVIDER=deepseek` 时使用。
 - `DEEPSEEK_MODEL`：DeepSeek 模型名称，默认 `deepseek-chat`。
+- `SCRAPE_WAIT_MS`：Firecrawl 抓取时额外等待的毫秒数，默认 `2000`。
+- `SCRAPE_TIMEOUT_MS`：Firecrawl 抓取的超时时间毫秒数，默认 `40000`。
 - `SUMMARY_PROVIDER`：选择 `openai`、`tongyi` 或 `deepseek` 作为摘要和文生图的提供方，默认 `tongyi`。
 - `BE_CONCISE`：设为 `true` 时生成更简洁的摘要。
 - `FETCHER_METHOD`：`crawling`（默认）或 `scraping`，决定新闻获取方式。

--- a/fetcher/scraping_fetcher.py
+++ b/fetcher/scraping_fetcher.py
@@ -3,7 +3,11 @@ import logging
 import os
 from firecrawl import FirecrawlApp, ScrapeOptions
 
+DEFAULT_WAIT_MS = 2000
+DEFAULT_TIMEOUT_MS = 40000
+
 logger = logging.getLogger(__name__)
+
 
 def fetch_articles_by_scraping(news_websites_scraping: dict):
     """
@@ -15,17 +19,23 @@ def fetch_articles_by_scraping(news_websites_scraping: dict):
     if not api_key_firecrawl:
         raise ValueError("Firecrawl API key not set in environment variables.")
 
+    wait_ms = int(os.getenv("SCRAPE_WAIT_MS", DEFAULT_WAIT_MS))
+    timeout_ms = int(os.getenv("SCRAPE_TIMEOUT_MS", DEFAULT_TIMEOUT_MS))
+
     app = FirecrawlApp(api_key=api_key_firecrawl)
     all_articles = []
 
     for url in news_websites_scraping:
         try:
             logger.info(f"[Scraping] Fetching URL: {url}")
-            scrape_result = app.scrape_url(url, formats=["markdown", "html"])
-    
+            options = ScrapeOptions(
+                formats=["markdown", "html"], waitFor=wait_ms, timeout=timeout_ms
+            )
+            scrape_result = app.scrape_url(url, options=options)
+
             if scrape_result and not isinstance(scrape_result, dict):
                 scrape_result = scrape_result.model_dump()
-    
+
             if "markdown" in scrape_result:
                 all_articles.append(scrape_result)
         except Exception as e:


### PR DESCRIPTION
## Summary
- support `SCRAPE_WAIT_MS` and `SCRAPE_TIMEOUT_MS` environment vars
- apply those options when scraping with Firecrawl
- document the new variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*