### PR TITLE
Add DeepSeek-R1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -r requirements.txt
 - `DASHSCOPE_API_KEY`：阿里云百炼 API Key，`SUMMARY_PROVIDER=tongyi` 时使用。
 - `DASHSCOPE_MODEL`：阿里云模型名称，默认 `qwen-plus`。
 - `DEEPSEEK_API_KEY`：DeepSeek API Key，`SUMMARY_PROVIDER=deepseek` 时使用。
-- `DEEPSEEK_MODEL`：DeepSeek 模型名称，默认 `deepseek-chat`。
+ - `DEEPSEEK_MODEL`：DeepSeek 模型名称，默认 `deepseek-reasoner`。
 - `SCRAPE_WAIT_MS`：Firecrawl 抓取时额外等待的毫秒数，默认 `2000`。
 - `SCRAPE_TIMEOUT_MS`：Firecrawl 抓取的超时时间毫秒数，默认 `40000`。
 - `SUMMARY_PROVIDER`：选择 `openai`、`tongyi` 或 `deepseek` 作为摘要和文生图的提供方，默认 `tongyi`。

--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -50,8 +50,10 @@ def initialize_llm_client():
         api_key = os.getenv("DEEPSEEK_API_KEY")
         if not api_key:
             raise ValueError("DEEPSEEK_API_KEY not set in environment variables.")
-        client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1")
-        model_name = os.getenv("DEEPSEEK_MODEL", "deepseek-chat")
+        # DeepSeek API is OpenAI compatible, specify its base_url
+        client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+        # Default to DeepSeek-R1 model
+        model_name = os.getenv("DEEPSEEK_MODEL", "deepseek-reasoner")
     else:
         api_key = os.getenv("DASHSCOPE_API_KEY")
         if not api_key:


### PR DESCRIPTION
## Summary
- update DeepSeek model defaults in docs
- update LLM initialization to use deepseek-reasoner with proper base URL

## Testing
- `python -m py_compile podcast_generator.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*